### PR TITLE
BCBlueprintSupport type "Editor" to "UncookedOnly"

### DIFF
--- a/Plugins/BCClient/BCClient.uplugin
+++ b/Plugins/BCClient/BCClient.uplugin
@@ -23,7 +23,7 @@
     },
     {
       "Name": "BCBlueprintSupport",
-      "Type": "Editor",
+      "Type": "UncookedOnly",
       "LoadingPhase": "PreDefault"
     },
     {


### PR DESCRIPTION
Fixed warning in Unreal 4.26.2
[Compiler] The node ' Authenticate Universal ' is from an Editor Only module, but is placed in a runtime blueprint! K2 Nodes should only be defined in a Developer or UncookedOnly module.