### PR TITLE
Hotfixes !

### DIFF
--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BlueprintProxies/BCRelayProxy.cpp
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BlueprintProxies/BCRelayProxy.cpp
@@ -2,9 +2,7 @@
 
 #include "BCClientPluginPrivatePCH.h"
 #include "BCRelayProxy.h"
-#include "BrainCloudClient.h"
 #include "ServerCall.h"
-
 #include "BCWrapperProxy.h"
 #include "BrainCloudWrapper.h"
 	

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BlueprintProxies/BCRelayProxy.h
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BlueprintProxies/BCRelayProxy.h
@@ -4,6 +4,7 @@
 
 #include "BCBlueprintCallProxyBase.h"
 #include "BrainCloudRelayComms.h"
+#include "BrainCloudWrapper.h"
 #include "BCRelayProxy.generated.h"
 
 UCLASS(MinimalAPI)

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudClient.cpp
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudClient.cpp
@@ -1,8 +1,8 @@
 // Copyright 2018 bitHeads, Inc. All Rights Reserved.
 
-#include "BCClientPluginPrivatePCH.h"
-#include "BrainCloudClient.h"
 
+#include "BrainCloudClient.h"
+#include "BCClientPluginPrivatePCH.h"
 #include "GameDelegates.h"
 #include "BrainCloudComms.h"
 #include "BrainCloudRTTComms.h"

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudComms.cpp
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudComms.cpp
@@ -1,8 +1,8 @@
 // Copyright 2018 bitHeads, Inc. All Rights Reserved.
 
-#include "BCClientPluginPrivatePCH.h"
-#include "BrainCloudComms.h"
 
+#include "BrainCloudComms.h"
+#include "BCClientPluginPrivatePCH.h"
 #include "IServerCallback.h"
 #include "IEventCallback.h"
 #include "IRewardCallback.h"

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudComms.h
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudComms.h
@@ -1,6 +1,7 @@
 // Copyright 2018 bitHeads, Inc. All Rights Reserved.
 
 #pragma once
+#include "IHttpRequest.h"
 
 class IEventCallback;
 class IRewardCallback;
@@ -11,7 +12,7 @@ class ServerCall;
 class BCFileUploader;
 class BrainCloudClient;
 class UBCBlueprintRestCallProxyBase;
-
+class IHttpRequest;
 class BrainCloudComms
 {
 	typedef TSharedRef<TArray<TSharedRef<ServerCall>>> PacketRef;

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudComms.h
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudComms.h
@@ -12,7 +12,6 @@ class ServerCall;
 class BCFileUploader;
 class BrainCloudClient;
 class UBCBlueprintRestCallProxyBase;
-class IHttpRequest;
 class BrainCloudComms
 {
 	typedef TSharedRef<TArray<TSharedRef<ServerCall>>> PacketRef;

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRTTComms.cpp
@@ -2,7 +2,6 @@
 
 #include "BCClientPluginPrivatePCH.h"
 #include "BrainCloudRTTComms.h"
-
 #include "Serialization/JsonTypes.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -544,7 +543,7 @@ void BrainCloudRTTComms::webSocket_OnClose()
 		if (m_disconnectedWithReason == true)
 		{
 			FString response;
-			TSharedRef<TJsonWriter<>> m_disconnectJson = TJsonWriterFactory<>::Create(&response);
+			TSharedRef<TJsonWriter<>> disconnectJson = TJsonWriterFactory<>::Create(&response);
 			UE_LOG(LogBrainCloudComms, Log, TEXT("RTT: Disconnect "), *response);
 		}
 	}

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRelay.cpp
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRelay.cpp
@@ -1,6 +1,6 @@
+#include "BrainCloudRelay.h"
 #include "BCClientPluginPrivatePCH.h"
 #include "BrainCloudClient.h"
-#include "BrainCloudRelay.h"
 #include "BrainCloudRelayComms.h"
 
 BrainCloudRelay::BrainCloudRelay(BrainCloudClient *in_client, BrainCloudRelayComms *in_comms) 

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
@@ -377,7 +377,7 @@ void BrainCloudRelayComms::sendRelay(const TArray<uint8> &in_data, const uint64 
 
 	// Store inverted player mask
 	uint64 playerMask = 0;
-	for (uint64 i = 0, length = (uint64)MAX_PLAYERS; i < length; ++i)
+	for (uint64 i = 0, len = (uint64)MAX_PLAYERS; i < len; ++i)
 	{
 		playerMask |= ((in_playerMask >> ((uint64)MAX_PLAYERS - i - 1)) & 1) << i;
 	}

--- a/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
+++ b/Plugins/BCClient/Source/BCClientPlugin/Private/BrainCloudRelayComms.cpp
@@ -2,7 +2,6 @@
 
 #include "BCClientPluginPrivatePCH.h"
 #include "BrainCloudRelayComms.h"
-
 #include "Serialization/JsonTypes.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -378,7 +377,7 @@ void BrainCloudRelayComms::sendRelay(const TArray<uint8> &in_data, const uint64 
 
 	// Store inverted player mask
 	uint64 playerMask = 0;
-	for (uint64 i = 0, len = (uint64)MAX_PLAYERS; i < len; ++i)
+	for (uint64 i = 0, length = (uint64)MAX_PLAYERS; i < length; ++i)
 	{
 		playerMask |= ((in_playerMask >> ((uint64)MAX_PLAYERS - i - 1)) & 1) << i;
 	}


### PR DESCRIPTION
- Within BrainCloudRelayComms.cpp and BrainCloudRTTComms.cpp have variable names that were shadowing other variables. Changed their name so compiler can be happy.
- Changed includes for files that need to have their own header first in the list of includes. Except for BCRelayProxy.cpp, BrainCloudRelayComms.cpp, BrainCloudRTTComms.cpp files, not sure why but BCClientPluginPrivatePCH.h needs to go first or the engine won't build.